### PR TITLE
Expose StacheRouteOptions to wire up lazy loaded components to nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 8.0.1 (2023-05-16)
+
+* **stache:** expose `StacheRouteOptions` to allow lazy loaded component routes to override the base path for navigation
+
 ## [8.0.0](https://github.com/blackbaud/stache/compare/8.0.0-rc.2...8.0.0) (2023-05-10)
 
 

--- a/apps/playground/src/app/navigation/lazy/lazy.component.html
+++ b/apps/playground/src/app/navigation/lazy/lazy.component.html
@@ -1,0 +1,30 @@
+<stache pageTitle="Lazy Pages">
+  <h3>Example</h3>
+  <p>
+    Core at the parallel universe was the mind of rumour, deceived to a
+    post-apocalyptic dosi.
+  </p>
+
+  <h3>Content</h3>
+  <p>
+    Sed posuere consectetur est at lobortis. Duis mollis, est non commodo
+    luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit. Aenean
+    lacinia bibendum nulla sed consectetur. Duis mollis, est non commodo luctus,
+    nisi erat porttitor ligula, eget lacinia odio sem nec elit. Donec id elit
+    non mi porta gravida at eget metus. Vivamus sagittis lacus vel augue laoreet
+    rutrum faucibus dolor auctor.
+  </p>
+
+  <p>
+    Donec sed odio dui. Curabitur blandit tempus porttitor. Nullam id dolor id
+    nibh ultricies vehicula ut id elit. Nullam quis risus eget urna mollis
+    ornare vel eu leo.
+  </p>
+
+  <h3>Lorem Ipsum</h3>
+  <p>
+    Donec id elit non mi porta gravida at eget metus. Cras justo odio, dapibus
+    ac facilisis in, egestas eget quam. Curabitur blandit tempus porttitor.
+    Vestibulum id ligula porta felis euismod semper.
+  </p>
+</stache>

--- a/apps/playground/src/app/navigation/lazy/lazy.component.ts
+++ b/apps/playground/src/app/navigation/lazy/lazy.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { StacheWrapperModule } from '@blackbaud/skyux-lib-stache';
+
+@Component({
+  standalone: true,
+  imports: [StacheWrapperModule],
+  selector: 'app-lazy',
+  templateUrl: './lazy.component.html',
+})
+export default class LazyComponent {}

--- a/apps/playground/src/app/navigation/navigation.module.ts
+++ b/apps/playground/src/app/navigation/navigation.module.ts
@@ -5,7 +5,11 @@ import {
   SkyCodeBlockModule,
   SkyCodeModule,
 } from '@blackbaud/skyux-lib-code-block';
-import { StacheModule, StacheRouterModule } from '@blackbaud/skyux-lib-stache';
+import {
+  STACHE_ROUTE_OPTIONS,
+  StacheModule,
+  StacheRouterModule,
+} from '@blackbaud/skyux-lib-stache';
 
 import { NavigationComponent } from './navigation.component';
 import { RecursionComponent } from './supporting-pages/recursion/recursion.component';
@@ -51,6 +55,26 @@ const routes: Routes = [
         name: 'Recursion',
       },
     },
+  },
+  {
+    path: 'lazy',
+    loadComponent: () => import('./lazy/lazy.component'),
+    providers: [
+      {
+        provide: STACHE_ROUTE_OPTIONS,
+        useValue: { basePath: 'navigation' },
+      },
+    ],
+  },
+  {
+    path: 'lazy/recursive',
+    loadComponent: () => import('./lazy/lazy.component'),
+    providers: [
+      {
+        provide: STACHE_ROUTE_OPTIONS,
+        useValue: { basePath: 'navigation' },
+      },
+    ],
   },
 ];
 

--- a/libs/stache/src/index.ts
+++ b/libs/stache/src/index.ts
@@ -32,6 +32,7 @@ export * from './lib/modules/page-header/page-header.module';
 
 export * from './lib/modules/page-summary/page-summary.module';
 
+export * from './lib/modules/router/route-options';
 export * from './lib/modules/router/route.service';
 export * from './lib/modules/router/router.module';
 

--- a/libs/stache/src/lib/modules/router/route-options.ts
+++ b/libs/stache/src/lib/modules/router/route-options.ts
@@ -1,6 +1,9 @@
-/**
- * @internal
- */
-export class StacheRouteOptions {
-  public path?: string;
+import { InjectionToken } from '@angular/core';
+
+export const STACHE_ROUTE_OPTIONS = new InjectionToken<StacheRouteOptions>(
+  'StacheRouteOptions'
+);
+
+export interface StacheRouteOptions {
+  basePath?: string;
 }

--- a/libs/stache/src/lib/modules/router/route.service.spec.ts
+++ b/libs/stache/src/lib/modules/router/route.service.spec.ts
@@ -427,7 +427,7 @@ describe('StacheRouteService', () => {
     });
     router = TestBed.inject(Router);
     routeService = new StacheRouteService(router as Router, mockRoutes, {
-      path: 'order-routes',
+      basePath: 'order-routes',
     });
     expect(routeService).toBeTruthy();
     await router.navigateByUrl('/order-routes');

--- a/libs/stache/src/lib/modules/router/route.service.ts
+++ b/libs/stache/src/lib/modules/router/route.service.ts
@@ -1,11 +1,5 @@
 import { Inject, Injectable, OnDestroy, Optional } from '@angular/core';
-import {
-  NavigationStart,
-  ROUTES,
-  Route,
-  Router,
-  Routes,
-} from '@angular/router';
+import { NavigationStart, ROUTES, Router, Routes } from '@angular/router';
 
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -15,7 +9,7 @@ import { numberConverter } from '../shared/input-converter';
 
 import { StacheRouteMetadataConfig } from './route-metadata-config';
 import { StacheRouteMetadataConfigJson } from './route-metadata-config-json';
-import { StacheRouteOptions } from './route-options';
+import { STACHE_ROUTE_OPTIONS, StacheRouteOptions } from './route-options';
 import { sortByName, sortByOrder } from './sort';
 
 type UnformattedStacheNavLink = {
@@ -69,6 +63,24 @@ function clone<T>(thing: T): T {
  * })
  * export class MyLazyLoadedModule {}
  * ```
+ * Lazy loaded components will lose the context provided by StacheRouterModule.forChild(...)
+ * You may override the StacheRouteOptions via a route provider to wire lazy components into navigation
+ * ```
+ *  const routes: Routes = [
+ *  {
+ *    path: 'lazy',
+ *    loadComponent: () => import('./path/to/lazy.component'),
+ *    providers: [
+ *      { provide: StacheRouteOptions, useValue: {basePath: 'nested'}}
+ *    ]
+ *    data: {
+ *      stache: {
+ *        name: 'Lazy',
+ *      },
+ *    },
+ *  },
+ * ];
+ * ```
  */
 @Injectable()
 export class StacheRouteService implements OnDestroy {
@@ -81,7 +93,7 @@ export class StacheRouteService implements OnDestroy {
   constructor(
     router: Router,
     @Optional() @Inject(ROUTES) routes?: Routes,
-    @Optional() options?: StacheRouteOptions
+    @Optional() @Inject(STACHE_ROUTE_OPTIONS) options?: StacheRouteOptions
   ) {
     this.#options = options;
     this.#router = router;
@@ -106,7 +118,7 @@ export class StacheRouteService implements OnDestroy {
 
     const rootPath = this.getActiveUrl().replace(/^\//, '').split('/')[0];
 
-    const appRoutes = this.#options?.path
+    const appRoutes = this.#options?.basePath
       ? this.#routes
       : this.#getRouteBranch(this.#routes, rootPath);
 
@@ -114,7 +126,7 @@ export class StacheRouteService implements OnDestroy {
       .filter((route) => {
         // If options.path is specified, it means that all routes are children
         // of the root path.
-        return this.#options?.path || route.path?.indexOf(rootPath) === 0;
+        return this.#options?.basePath || route.path?.indexOf(rootPath) === 0;
       })
       .map((route) => {
         const path = this.#prependOptionsPath(route.path);
@@ -176,8 +188,10 @@ export class StacheRouteService implements OnDestroy {
   #prependOptionsPath(path: string | undefined): string | undefined {
     // If options.path is specified, all routes are children of the root path,
     // so prepend it to each path when building the path for navigation.
-    if (this.#options?.path) {
-      path = path ? `${this.#options.path}/${path}` : this.#options.path;
+    if (this.#options?.basePath) {
+      path = path
+        ? `${this.#options.basePath}/${path}`
+        : this.#options.basePath;
     }
 
     return path;

--- a/libs/stache/src/lib/modules/router/router.module.ts
+++ b/libs/stache/src/lib/modules/router/router.module.ts
@@ -9,7 +9,7 @@ import { StacheRouteService } from './route.service';
 })
 export class StacheRouterModule {
   public static forChild(
-    path: string
+    basePath: string
   ): ModuleWithProviders<StacheRouterModule> {
     return {
       ngModule: StacheRouterModule,
@@ -17,8 +17,9 @@ export class StacheRouterModule {
         {
           provide: StacheRouteService,
           useFactory: (router: Router, routes: Routes): StacheRouteService => {
-            const options = new StacheRouteOptions();
-            options.path = path;
+            const options: StacheRouteOptions = {
+              basePath,
+            };
 
             return new StacheRouteService(router, routes, options);
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stache",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stache",
-      "version": "8.0.0-rc.2",
+      "version": "8.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stache",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "license": "MIT",
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
Admittedly, this is an inelegant workaround but lazy components present a challenge for DI. 

The issue is: 
`StacheRouterModule.forChild(...)` is meant to be used in lazy loaded modules to allow for those routes to be available in the nav sidebar or breadcrumbs. However, lazy loaded components that import `StacheWrapperModule` will be given a new injector that lacks this context. 

This change simply allows for the `StacheRouteOptions` to be manually specified, so that any route which uses `loadComponent` can provide a custom value that matches up with what the route service expects. 

I added a working example of this in the playground project

```ts
const routes: Routes = [
  {
    path: '',
    component: NavigationComponent,
    data: {
      stache: {
        name: 'Navigation',
        order: 2,
      },
    },
  },
  {
    path: 'lazy',
    loadComponent: () => import('./lazy/lazy.component'),
    providers: [
      {
        provide: STACHE_ROUTE_OPTIONS,
        useValue: { basePath: 'navigation' },
      },
    ],
  },
  {
    path: 'lazy/recursive',
    loadComponent: () => import('./lazy/lazy.component'),
    providers: [
      {
        provide: STACHE_ROUTE_OPTIONS,
        useValue: { basePath: 'navigation' },
      },
    ],
  },
];

@NgModule({
  imports: [RouterModule.forChild(routes)],
  exports: [RouterModule],
})
export class NavigationRoutingModule {}

@NgModule({
  declarations: [...],
  imports: [
    ...
    StacheRouterModule.forChild('navigation'),
  ],
})
export class NavigationModule {}
```