### PR TITLE
fix(stache): respect strict CSP when injecting Google Analytics tag manager

### DIFF
--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.spec.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.spec.ts
@@ -37,8 +37,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
           .createSpy('createElement')
           .and.callFake(function (tag: string) {
             const element = {
-              async: false,
-              src: '',
+              textContent: '',
               setAttribute: jasmine.createSpy('setAttribute'),
             };
             return element;
@@ -196,8 +195,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
       StacheGoogleAnalyticsDirective,
     );
     const mockScript = {
-      async: false,
-      src: '',
+      textContent: '',
       setAttribute: jasmine.createSpy('setAttribute'),
     };
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
@@ -209,10 +207,9 @@ describe('StacheGoogleAnalyticsDirective', () => {
     expect(
       mockWindowService.nativeWindow.document.createElement,
     ).toHaveBeenCalledWith('script');
-    expect(mockScript.async).toBe(true);
-    expect(mockScript.src).toBe(
-      'https://www.googletagmanager.com/gtm.js?id=GTM-W56QP9',
-    );
+    expect(mockScript.textContent).toContain('GTM-W56QP9');
+    expect(mockScript.textContent).toContain('gtm.start');
+    expect(mockScript.textContent).toContain('querySelector');
     expect(
       mockWindowService.nativeWindow.document.head.appendChild,
     ).toHaveBeenCalledWith(mockScript);
@@ -240,8 +237,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
       StacheGoogleAnalyticsDirective,
     );
     const mockScript = {
-      async: false,
-      src: '',
+      textContent: '',
       setAttribute: jasmine.createSpy('setAttribute'),
     };
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
@@ -261,8 +257,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
       StacheGoogleAnalyticsDirective,
     );
     const mockScript = {
-      async: false,
-      src: '',
+      textContent: '',
       setAttribute: jasmine.createSpy('setAttribute'),
     };
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
@@ -277,57 +272,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
     );
   });
 
-  it('should initialize dataLayer if it does not exist', () => {
-    const directiveInstance = directiveElement.injector.get(
-      StacheGoogleAnalyticsDirective,
-    );
-    mockWindowService.nativeWindow.dataLayer = undefined;
-    const mockScript = {
-      async: false,
-      src: '',
-      setAttribute: jasmine.createSpy('setAttribute'),
-    };
-    mockWindowService.nativeWindow.document.createElement.and.returnValue(
-      mockScript,
-    );
-
-    directiveInstance.addGoogleTagManagerScript();
-
-    expect(mockWindowService.nativeWindow.dataLayer).toEqual(
-      jasmine.any(Array),
-    );
-    expect(mockWindowService.nativeWindow.dataLayer.length).toBe(1);
-    expect(mockWindowService.nativeWindow.dataLayer[0]).toEqual({
-      'gtm.start': jasmine.any(Number),
-      event: 'gtm.js',
-    });
-  });
-
-  it('should push to existing dataLayer if it already exists', () => {
-    const directiveInstance = directiveElement.injector.get(
-      StacheGoogleAnalyticsDirective,
-    );
-    mockWindowService.nativeWindow.dataLayer = ['existing-item'];
-    const mockScript = {
-      async: false,
-      src: '',
-      setAttribute: jasmine.createSpy('setAttribute'),
-    };
-    mockWindowService.nativeWindow.document.createElement.and.returnValue(
-      mockScript,
-    );
-
-    directiveInstance.addGoogleTagManagerScript();
-
-    expect(mockWindowService.nativeWindow.dataLayer.length).toBe(2);
-    expect(mockWindowService.nativeWindow.dataLayer[0]).toBe('existing-item');
-    expect(mockWindowService.nativeWindow.dataLayer[1]).toEqual({
-      'gtm.start': jasmine.any(Number),
-      event: 'gtm.js',
-    });
-  });
-
-  it('should use custom tagManagerContainerId in script src', () => {
+  it('should use custom tagManagerContainerId in script content', () => {
     const directiveInstance = directiveElement.injector.get(
       StacheGoogleAnalyticsDirective,
     );
@@ -341,8 +286,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
     directiveInstance.updateDefaultConfigs();
 
     const mockScript = {
-      async: false,
-      src: '',
+      textContent: '',
       setAttribute: jasmine.createSpy('setAttribute'),
     };
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
@@ -351,9 +295,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
 
     directiveInstance.addGoogleTagManagerScript();
 
-    expect(mockScript.src).toBe(
-      'https://www.googletagmanager.com/gtm.js?id=GTM-CUSTOM',
-    );
+    expect(mockScript.textContent).toContain('GTM-CUSTOM');
   });
 
   it('should call initGoogleAnalytics and bindPageViewsToRouter when conditions are met', () => {
@@ -371,7 +313,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
     expect(directiveInstance.bindPageViewsToRouter).toHaveBeenCalled();
   });
 
-  it('should initialize Google Analytics', () => {
+  it('should initialize Google Analytics without using eval', () => {
     const directiveInstance = directiveElement.injector.get(
       StacheGoogleAnalyticsDirective,
     );

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.spec.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.spec.ts
@@ -22,22 +22,21 @@ describe('StacheGoogleAnalyticsDirective', () => {
 
   class MockWindowService {
     public nativeWindow = {
-      eval: function () {
-        this.ga = () => true;
-      },
       ga: false,
       dataLayer: undefined,
       document: {
         getElementById: jasmine
           .createSpy('getElementById')
-          .and.callFake(function (id: any) {
+          .and.callFake(function () {
             return false;
           }),
         createElement: jasmine
           .createSpy('createElement')
-          .and.callFake(function (tag: string) {
+          .and.callFake(function () {
             const element = {
               textContent: '',
+              src: '',
+              async: false,
               setAttribute: jasmine.createSpy('setAttribute'),
             };
             return element;
@@ -195,7 +194,8 @@ describe('StacheGoogleAnalyticsDirective', () => {
       StacheGoogleAnalyticsDirective,
     );
     const mockScript = {
-      textContent: '',
+      src: '',
+      async: false,
       setAttribute: jasmine.createSpy('setAttribute'),
     };
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
@@ -207,9 +207,15 @@ describe('StacheGoogleAnalyticsDirective', () => {
     expect(
       mockWindowService.nativeWindow.document.createElement,
     ).toHaveBeenCalledWith('script');
-    expect(mockScript.textContent).toContain('GTM-W56QP9');
-    expect(mockScript.textContent).toContain('gtm.start');
-    expect(mockScript.textContent).toContain('querySelector');
+    expect(mockScript.src).toContain('GTM-W56QP9');
+    expect(mockScript.src).toContain('googletagmanager.com/gtm.js');
+    expect(mockScript.async).toBe(true);
+    expect(mockWindowService.nativeWindow.dataLayer).toBeDefined();
+    expect(mockWindowService.nativeWindow.dataLayer.length).toBe(1);
+    expect(
+      mockWindowService.nativeWindow.dataLayer[0]['gtm.start'],
+    ).toBeDefined();
+    expect(mockWindowService.nativeWindow.dataLayer[0].event).toBe('gtm.js');
     expect(
       mockWindowService.nativeWindow.document.head.appendChild,
     ).toHaveBeenCalledWith(mockScript);
@@ -237,7 +243,8 @@ describe('StacheGoogleAnalyticsDirective', () => {
       StacheGoogleAnalyticsDirective,
     );
     const mockScript = {
-      textContent: '',
+      src: '',
+      async: false,
       setAttribute: jasmine.createSpy('setAttribute'),
     };
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
@@ -257,7 +264,8 @@ describe('StacheGoogleAnalyticsDirective', () => {
       StacheGoogleAnalyticsDirective,
     );
     const mockScript = {
-      textContent: '',
+      src: '',
+      async: false,
       setAttribute: jasmine.createSpy('setAttribute'),
     };
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
@@ -272,7 +280,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
     );
   });
 
-  it('should use custom tagManagerContainerId in script content', () => {
+  it('should use custom tagManagerContainerId in script src', () => {
     const directiveInstance = directiveElement.injector.get(
       StacheGoogleAnalyticsDirective,
     );
@@ -286,7 +294,8 @@ describe('StacheGoogleAnalyticsDirective', () => {
     directiveInstance.updateDefaultConfigs();
 
     const mockScript = {
-      textContent: '',
+      src: '',
+      async: false,
       setAttribute: jasmine.createSpy('setAttribute'),
     };
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
@@ -295,7 +304,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
 
     directiveInstance.addGoogleTagManagerScript();
 
-    expect(mockScript.textContent).toContain('GTM-CUSTOM');
+    expect(mockScript.src).toContain('GTM-CUSTOM');
   });
 
   it('should call initGoogleAnalytics and bindPageViewsToRouter when conditions are met', () => {

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.spec.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.spec.ts
@@ -1,3 +1,4 @@
+import { CSP_NONCE } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NavigationEnd, Router } from '@angular/router';
@@ -25,12 +26,26 @@ describe('StacheGoogleAnalyticsDirective', () => {
         this.ga = () => true;
       },
       ga: false,
+      dataLayer: undefined,
       document: {
         getElementById: jasmine
           .createSpy('getElementById')
           .and.callFake(function (id: any) {
             return false;
           }),
+        createElement: jasmine
+          .createSpy('createElement')
+          .and.callFake(function (tag: string) {
+            const element = {
+              async: false,
+              src: '',
+              setAttribute: jasmine.createSpy('setAttribute'),
+            };
+            return element;
+          }),
+        head: {
+          appendChild: jasmine.createSpy('appendChild'),
+        },
       },
     };
   }
@@ -69,6 +84,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
         { provide: SkyAppConfig, useValue: mockConfigService },
         { provide: StacheWindowRef, useValue: mockWindowService },
         { provide: Router, useValue: mockRouter },
+        { provide: CSP_NONCE, useValue: null },
       ],
     }).compileComponents();
 
@@ -173,5 +189,294 @@ describe('StacheGoogleAnalyticsDirective', () => {
     spyOn(directiveInstance, 'addGoogleTagManagerScript').and.callThrough();
     fixture.detectChanges();
     expect(directiveInstance.addGoogleTagManagerScript).not.toHaveBeenCalled();
+  });
+
+  it('should create and append script tag with correct attributes', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    const mockScript = {
+      async: false,
+      src: '',
+      setAttribute: jasmine.createSpy('setAttribute'),
+    };
+    mockWindowService.nativeWindow.document.createElement.and.returnValue(
+      mockScript,
+    );
+
+    directiveInstance.addGoogleTagManagerScript();
+
+    expect(
+      mockWindowService.nativeWindow.document.createElement,
+    ).toHaveBeenCalledWith('script');
+    expect(mockScript.async).toBe(true);
+    expect(mockScript.src).toBe(
+      'https://www.googletagmanager.com/gtm.js?id=GTM-W56QP9',
+    );
+    expect(
+      mockWindowService.nativeWindow.document.head.appendChild,
+    ).toHaveBeenCalledWith(mockScript);
+  });
+
+  it('should set nonce attribute on script if CSP_NONCE is provided', () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      declarations: [StacheGoogleAnalyticsTestComponent],
+      imports: [StacheAnalyticsModule],
+      providers: [
+        { provide: SkyAppConfig, useValue: mockConfigService },
+        { provide: StacheWindowRef, useValue: mockWindowService },
+        { provide: Router, useValue: mockRouter },
+        { provide: CSP_NONCE, useValue: 'test-nonce-123' },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(StacheGoogleAnalyticsTestComponent);
+    directiveElement = fixture.debugElement.query(
+      By.directive(StacheGoogleAnalyticsDirective),
+    );
+
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    const mockScript = {
+      async: false,
+      src: '',
+      setAttribute: jasmine.createSpy('setAttribute'),
+    };
+    mockWindowService.nativeWindow.document.createElement.and.returnValue(
+      mockScript,
+    );
+
+    directiveInstance.addGoogleTagManagerScript();
+
+    expect(mockScript.setAttribute).toHaveBeenCalledWith(
+      'nonce',
+      'test-nonce-123',
+    );
+  });
+
+  it('should not set nonce attribute on script if CSP_NONCE is null', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    const mockScript = {
+      async: false,
+      src: '',
+      setAttribute: jasmine.createSpy('setAttribute'),
+    };
+    mockWindowService.nativeWindow.document.createElement.and.returnValue(
+      mockScript,
+    );
+
+    directiveInstance.addGoogleTagManagerScript();
+
+    expect(mockScript.setAttribute).not.toHaveBeenCalledWith(
+      'nonce',
+      jasmine.any(String),
+    );
+  });
+
+  it('should initialize dataLayer if it does not exist', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockWindowService.nativeWindow.dataLayer = undefined;
+    const mockScript = {
+      async: false,
+      src: '',
+      setAttribute: jasmine.createSpy('setAttribute'),
+    };
+    mockWindowService.nativeWindow.document.createElement.and.returnValue(
+      mockScript,
+    );
+
+    directiveInstance.addGoogleTagManagerScript();
+
+    expect(mockWindowService.nativeWindow.dataLayer).toEqual(
+      jasmine.any(Array),
+    );
+    expect(mockWindowService.nativeWindow.dataLayer.length).toBe(1);
+    expect(mockWindowService.nativeWindow.dataLayer[0]).toEqual({
+      'gtm.start': jasmine.any(Number),
+      event: 'gtm.js',
+    });
+  });
+
+  it('should push to existing dataLayer if it already exists', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockWindowService.nativeWindow.dataLayer = ['existing-item'];
+    const mockScript = {
+      async: false,
+      src: '',
+      setAttribute: jasmine.createSpy('setAttribute'),
+    };
+    mockWindowService.nativeWindow.document.createElement.and.returnValue(
+      mockScript,
+    );
+
+    directiveInstance.addGoogleTagManagerScript();
+
+    expect(mockWindowService.nativeWindow.dataLayer.length).toBe(2);
+    expect(mockWindowService.nativeWindow.dataLayer[0]).toBe('existing-item');
+    expect(mockWindowService.nativeWindow.dataLayer[1]).toEqual({
+      'gtm.start': jasmine.any(Number),
+      event: 'gtm.js',
+    });
+  });
+
+  it('should use custom tagManagerContainerId in script src', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockConfigService.skyux.appSettings = {
+      stache: {
+        googleAnalytics: {
+          tagManagerContainerId: 'GTM-CUSTOM',
+        },
+      },
+    };
+    directiveInstance.updateDefaultConfigs();
+
+    const mockScript = {
+      async: false,
+      src: '',
+      setAttribute: jasmine.createSpy('setAttribute'),
+    };
+    mockWindowService.nativeWindow.document.createElement.and.returnValue(
+      mockScript,
+    );
+
+    directiveInstance.addGoogleTagManagerScript();
+
+    expect(mockScript.src).toBe(
+      'https://www.googletagmanager.com/gtm.js?id=GTM-CUSTOM',
+    );
+  });
+
+  it('should call initGoogleAnalytics and bindPageViewsToRouter when conditions are met', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    spyOn(directiveInstance, 'addGoogleTagManagerScript').and.callThrough();
+    spyOn(directiveInstance, 'initGoogleAnalytics').and.callThrough();
+    spyOn(directiveInstance, 'bindPageViewsToRouter').and.callThrough();
+
+    directiveInstance.ngOnInit();
+
+    expect(directiveInstance.addGoogleTagManagerScript).toHaveBeenCalled();
+    expect(directiveInstance.initGoogleAnalytics).toHaveBeenCalled();
+    expect(directiveInstance.bindPageViewsToRouter).toHaveBeenCalled();
+  });
+
+  it('should initialize Google Analytics', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockWindowService.nativeWindow.ga = undefined;
+    mockWindowService.nativeWindow['GoogleAnalyticsObject'] = undefined;
+
+    directiveInstance.initGoogleAnalytics();
+
+    expect(mockWindowService.nativeWindow['GoogleAnalyticsObject']).toBe('ga');
+    expect(mockWindowService.nativeWindow.ga).toBeDefined();
+    expect(typeof mockWindowService.nativeWindow.ga).toBe('function');
+    expect(mockWindowService.nativeWindow.ga.l).toEqual(jasmine.any(Number));
+    expect(mockWindowService.nativeWindow.ga.q).toEqual(jasmine.any(Array));
+  });
+
+  it('should call ga create after initializing Google Analytics', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockWindowService.nativeWindow.ga = undefined;
+    mockWindowService.nativeWindow['GoogleAnalyticsObject'] = undefined;
+
+    directiveInstance.initGoogleAnalytics();
+
+    // The ga function should have been called with create
+    expect(mockWindowService.nativeWindow.ga.q.length).toBeGreaterThan(0);
+    const firstCall = mockWindowService.nativeWindow.ga.q[0];
+    expect(firstCall[0]).toBe('create');
+    expect(firstCall[1]).toBe('UA-2418840-1');
+    expect(firstCall[2]).toBe('auto');
+  });
+
+  it('should track page views for NavigationEnd events', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockWindowService.nativeWindow.ga = jasmine.createSpy('ga');
+    directiveInstance['appName'] = 'test-app';
+
+    directiveInstance.bindPageViewsToRouter();
+
+    // Simulate a NavigationEnd event
+    const navigationEndEvent = new NavigationEnd(1, '/test-url', '/test-url');
+    mockRouter.events = observableOf(navigationEndEvent);
+    directiveInstance.bindPageViewsToRouter();
+
+    expect(mockWindowService.nativeWindow.ga).toHaveBeenCalledWith(
+      'set',
+      'page',
+      'test-app/test-url',
+    );
+    expect(mockWindowService.nativeWindow.ga).toHaveBeenCalledWith(
+      'send',
+      'pageview',
+    );
+  });
+
+  it('should handle enabled setting as boolean false', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockConfigService.skyux.appSettings = {
+      stache: {
+        googleAnalytics: {
+          enabled: false,
+        },
+      },
+    };
+
+    directiveInstance.updateDefaultConfigs();
+
+    expect(directiveInstance['isEnabled']).toBe(false);
+  });
+
+  it('should handle enabled setting as string "false"', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockConfigService.skyux.appSettings = {
+      stache: {
+        googleAnalytics: {
+          enabled: 'false',
+        },
+      },
+    };
+
+    directiveInstance.updateDefaultConfigs();
+
+    expect(directiveInstance['isEnabled']).toBe(false);
+  });
+
+  it('should keep enabled as true for other values', () => {
+    const directiveInstance = directiveElement.injector.get(
+      StacheGoogleAnalyticsDirective,
+    );
+    mockConfigService.skyux.appSettings = {
+      stache: {
+        googleAnalytics: {
+          enabled: 'true',
+        },
+      },
+    };
+
+    directiveInstance.updateDefaultConfigs();
+
+    expect(directiveInstance['isEnabled']).toBe(true);
   });
 });

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.spec.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.spec.ts
@@ -35,8 +35,6 @@ describe('StacheGoogleAnalyticsDirective', () => {
           .and.callFake(function () {
             const element = {
               textContent: '',
-              src: '',
-              async: false,
               setAttribute: jasmine.createSpy('setAttribute'),
             };
             return element;
@@ -193,11 +191,11 @@ describe('StacheGoogleAnalyticsDirective', () => {
     const directiveInstance = directiveElement.injector.get(
       StacheGoogleAnalyticsDirective,
     );
+
     const mockScript = {
-      src: '',
-      async: false,
       setAttribute: jasmine.createSpy('setAttribute'),
     };
+
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
       mockScript,
     );
@@ -207,15 +205,20 @@ describe('StacheGoogleAnalyticsDirective', () => {
     expect(
       mockWindowService.nativeWindow.document.createElement,
     ).toHaveBeenCalledWith('script');
-    expect(mockScript.src).toContain('GTM-W56QP9');
-    expect(mockScript.src).toContain('googletagmanager.com/gtm.js');
-    expect(mockScript.async).toBe(true);
+
+    expect(mockScript.setAttribute).toHaveBeenCalledWith('async', 'async');
+    expect(mockScript.setAttribute).toHaveBeenCalledWith(
+      'src',
+      'https://www.googletagmanager.com/gtm.js?id=GTM-W56QP9',
+    );
+
     expect(mockWindowService.nativeWindow.dataLayer).toBeDefined();
     expect(mockWindowService.nativeWindow.dataLayer.length).toBe(1);
     expect(
       mockWindowService.nativeWindow.dataLayer[0]['gtm.start'],
     ).toBeDefined();
     expect(mockWindowService.nativeWindow.dataLayer[0].event).toBe('gtm.js');
+
     expect(
       mockWindowService.nativeWindow.document.head.appendChild,
     ).toHaveBeenCalledWith(mockScript);
@@ -242,11 +245,11 @@ describe('StacheGoogleAnalyticsDirective', () => {
     const directiveInstance = directiveElement.injector.get(
       StacheGoogleAnalyticsDirective,
     );
+
     const mockScript = {
-      src: '',
-      async: false,
       setAttribute: jasmine.createSpy('setAttribute'),
     };
+
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
       mockScript,
     );
@@ -263,11 +266,11 @@ describe('StacheGoogleAnalyticsDirective', () => {
     const directiveInstance = directiveElement.injector.get(
       StacheGoogleAnalyticsDirective,
     );
+
     const mockScript = {
-      src: '',
-      async: false,
       setAttribute: jasmine.createSpy('setAttribute'),
     };
+
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
       mockScript,
     );
@@ -284,6 +287,7 @@ describe('StacheGoogleAnalyticsDirective', () => {
     const directiveInstance = directiveElement.injector.get(
       StacheGoogleAnalyticsDirective,
     );
+
     mockConfigService.skyux.appSettings = {
       stache: {
         googleAnalytics: {
@@ -291,20 +295,23 @@ describe('StacheGoogleAnalyticsDirective', () => {
         },
       },
     };
+
     directiveInstance.updateDefaultConfigs();
 
     const mockScript = {
-      src: '',
-      async: false,
       setAttribute: jasmine.createSpy('setAttribute'),
     };
+
     mockWindowService.nativeWindow.document.createElement.and.returnValue(
       mockScript,
     );
 
     directiveInstance.addGoogleTagManagerScript();
 
-    expect(mockScript.src).toContain('GTM-CUSTOM');
+    expect(mockScript.setAttribute).toHaveBeenCalledWith(
+      'src',
+      'https://www.googletagmanager.com/gtm.js?id=GTM-CUSTOM',
+    );
   });
 
   it('should call initGoogleAnalytics and bindPageViewsToRouter when conditions are met', () => {

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
@@ -37,20 +37,21 @@ export class StacheGoogleAnalyticsDirective implements OnInit {
 
   public addGoogleTagManagerScript(): void {
     const doc = this.windowRef.nativeWindow.document;
+    const win = this.windowRef.nativeWindow;
+
+    win.dataLayer = win.dataLayer || [];
+    win.dataLayer.push({
+      'gtm.start': new Date().getTime(),
+      event: 'gtm.js',
+    });
+
     const script = doc.createElement('script');
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtm.js?id=${this.tagManagerContainerId}`;
 
     if (this.#nonce) {
       script.setAttribute('nonce', this.#nonce);
     }
-
-    script.textContent = `
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
-      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','${this.tagManagerContainerId}');
-    `;
 
     doc.head.appendChild(script);
   }
@@ -88,7 +89,7 @@ export class StacheGoogleAnalyticsDirective implements OnInit {
     });
   }
 
-  private updateDefaultConfigs() {
+  private updateDefaultConfigs(): void {
     // TODO: the config service should handle defaults!
     const appSettings = this.configService.skyux.appSettings || {};
     appSettings.stache = appSettings.stache || {};

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, OnInit } from '@angular/core';
+import { CSP_NONCE, Directive, OnInit, inject } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { SkyAppConfig } from '@skyux/config';
 
@@ -9,6 +9,8 @@ import { StacheWindowRef } from '../shared/window-ref';
   standalone: false,
 })
 export class StacheGoogleAnalyticsDirective implements OnInit {
+  readonly #nonce = inject(CSP_NONCE, { optional: true });
+
   private tagManagerContainerId = 'GTM-W56QP9';
   private analyticsClientId = 'UA-2418840-1';
   private isEnabled = true;
@@ -34,13 +36,27 @@ export class StacheGoogleAnalyticsDirective implements OnInit {
   }
 
   public addGoogleTagManagerScript(): void {
-    this.windowRef.nativeWindow.eval(`
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','${this.tagManagerContainerId}');
-    `);
+    const doc = this.windowRef.nativeWindow.document;
+    const script = doc.createElement('script');
+
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtm.js?id=${this.tagManagerContainerId}`;
+
+    if (this.#nonce) {
+      script.setAttribute('nonce', this.#nonce);
+    }
+
+    doc.head.appendChild(script);
+
+    // Optionally, initialize dataLayer for GTM
+    if (!this.windowRef.nativeWindow.dataLayer) {
+      this.windowRef.nativeWindow.dataLayer = [];
+    }
+
+    this.windowRef.nativeWindow.dataLayer.push({
+      'gtm.start': new Date().getTime(),
+      event: 'gtm.js',
+    });
   }
 
   /**

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
@@ -36,24 +36,29 @@ export class StacheGoogleAnalyticsDirective implements OnInit {
   }
 
   public addGoogleTagManagerScript(): void {
-    const doc = this.windowRef.nativeWindow.document;
-    const win = this.windowRef.nativeWindow;
+    const win = this.windowRef.nativeWindow as {
+      dataLayer?: unknown[];
+      document: Document;
+    };
 
-    win.dataLayer = win.dataLayer || [];
+    win.dataLayer ??= [];
     win.dataLayer.push({
       'gtm.start': new Date().getTime(),
       event: 'gtm.js',
     });
 
-    const script = doc.createElement('script');
-    script.async = true;
-    script.src = `https://www.googletagmanager.com/gtm.js?id=${this.tagManagerContainerId}`;
+    const script = win.document.createElement('script');
+    script.setAttribute('async', 'async');
+    script.setAttribute(
+      'src',
+      `https://www.googletagmanager.com/gtm.js?id=${this.tagManagerContainerId}`,
+    );
 
     if (this.#nonce) {
       script.setAttribute('nonce', this.#nonce);
     }
 
-    doc.head.appendChild(script);
+    win.document.head.appendChild(script);
   }
 
   /**

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
@@ -65,15 +65,19 @@ export class StacheGoogleAnalyticsDirective implements OnInit {
    * subscribe to our router events and track SPA page views.
    */
   public initGoogleAnalytics(): void {
-    this.windowRef.nativeWindow.eval(`
-      (function(i,r) {
-        i['GoogleAnalyticsObject']=r;
-        i[r]=i[r]||function() {
-          (i[r].q=i[r].q||[]).push(arguments)},
-          i[r].l=1*new Date();
-      })(window,'ga');
-    `);
-    this.windowRef.nativeWindow.ga('create', this.analyticsClientId, 'auto');
+    const win = this.windowRef.nativeWindow;
+
+    win['GoogleAnalyticsObject'] = 'ga';
+
+    win.ga =
+      win.ga ||
+      function () {
+        (win.ga.q = win.ga.q || []).push(arguments);
+      };
+
+    win.ga.l = new Date().getTime();
+
+    win.ga('create', this.analyticsClientId, 'auto');
   }
 
   public bindPageViewsToRouter(): void {

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
@@ -39,24 +39,20 @@ export class StacheGoogleAnalyticsDirective implements OnInit {
     const doc = this.windowRef.nativeWindow.document;
     const script = doc.createElement('script');
 
-    script.async = true;
-    script.src = `https://www.googletagmanager.com/gtm.js?id=${this.tagManagerContainerId}`;
-
     if (this.#nonce) {
       script.setAttribute('nonce', this.#nonce);
     }
 
+    script.textContent = `
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;var n=d.querySelector('[nonce]');
+      n&&j.setAttribute('nonce',n.nonce||n.getAttribute('nonce'));f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','${this.tagManagerContainerId}');
+    `;
+
     doc.head.appendChild(script);
-
-    // Optionally, initialize dataLayer for GTM
-    if (!this.windowRef.nativeWindow.dataLayer) {
-      this.windowRef.nativeWindow.dataLayer = [];
-    }
-
-    this.windowRef.nativeWindow.dataLayer.push({
-      'gtm.start': new Date().getTime(),
-      event: 'gtm.js',
-    });
   }
 
   /**

--- a/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
+++ b/libs/stache/src/lib/modules/analytics/google-analytics.directive.ts
@@ -67,8 +67,8 @@ export class StacheGoogleAnalyticsDirective implements OnInit {
 
     win.ga =
       win.ga ||
-      function () {
-        (win.ga.q = win.ga.q || []).push(arguments);
+      function (...args: unknown[]): void {
+        (win.ga.q = win.ga.q || []).push(args);
       };
 
     win.ga.l = new Date().getTime();


### PR DESCRIPTION
[AB#3399701](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3399701)