### PR TITLE
fix(stache): sidebar expand and collapse buttons use `sky-icon` and position onscreen

### DIFF
--- a/libs/stache/src/lib/modules/sidebar/sidebar-wrapper.component.html
+++ b/libs/stache/src/lib/modules/sidebar/sidebar-wrapper.component.html
@@ -9,17 +9,17 @@
   <div class="stache-sidebar-buttons">
     <button
       type="button"
-      class="sky-btn sky-btn-default stache-sidebar-button"
+      class="sky-btn sky-btn-default sky-btn-icon stache-sidebar-button"
       [attr.aria-controls]="elementId"
       [attr.aria-expanded]="sidebarOpen"
       [attr.title]="'stache_sidebar_toggle_button' | skyLibResources"
       (click)="toggleSidebar()"
     >
       @if (sidebarOpen) {
-        <i class="fa fa-chevron-left" aria-hidden="true"></i>
+        <sky-icon iconName="chevron-left" />
       }
       @if (!sidebarOpen) {
-        <i class="fa fa-chevron-right" aria-hidden="true"></i>
+        <sky-icon iconName="chevron-right" />
       }
     </button>
   </div>

--- a/libs/stache/src/lib/modules/sidebar/sidebar-wrapper.component.scss
+++ b/libs/stache/src/lib/modules/sidebar/sidebar-wrapper.component.scss
@@ -38,7 +38,9 @@
     margin-left: vars.$stache-sidebar-column-width * -1;
 
     .stache-sidebar-buttons {
-      right: -36px;
+      right: calc(
+        -36px - calc(calc(vars.$stache-container-padding - 36px) / 2)
+      );
       top: 20px;
     }
   }
@@ -47,4 +49,11 @@
     position: fixed !important;
     left: auto;
   }
+}
+
+// Adjust default sidecar button to be same 36px as modern.
+.stache-sidebar-button:not(.sky-theme-modern *) {
+  padding-left: 7px;
+  padding-right: 7px;
+  line-height: 1;
 }

--- a/libs/stache/src/lib/modules/sidebar/sidebar.module.ts
+++ b/libs/stache/src/lib/modules/sidebar/sidebar.module.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
+import { SkyIconModule } from '@skyux/icon';
 
 import { StacheNavModule } from '../nav/nav.module';
 import { SkyStacheResourcesModule } from '../shared/sky-stache-resources.module';
@@ -10,7 +11,12 @@ import { StacheSidebarComponent } from './sidebar.component';
 
 @NgModule({
   declarations: [StacheSidebarComponent, StacheSidebarWrapperComponent],
-  imports: [CommonModule, StacheNavModule, SkyStacheResourcesModule],
+  imports: [
+    CommonModule,
+    StacheNavModule,
+    SkyIconModule,
+    SkyStacheResourcesModule,
+  ],
   exports: [StacheSidebarComponent, StacheSidebarWrapperComponent],
   providers: [StacheWindowRef],
 })


### PR DESCRIPTION
[AB#3519134](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3519134)

NOTE: Talked with Kerry and we are ok with not tokenizing the button positioning for now. Will address further tokenization in a future Epic.