### PR TITLE
fix(stache)!: action button icons are now passed to the updated internal `iconName` input

### DIFF
--- a/apps/playground/src/app/components/components.component.ts
+++ b/apps/playground/src/app/components/components.component.ts
@@ -14,17 +14,17 @@ export class ComponentsPlaygroundComponent {
       path: 'components/code-block/code-block',
     },
     {
-      icon: 'photo',
+      icon: 'window-header-horizontal',
       name: 'Hero',
       path: 'components/media/hero',
     },
     {
-      icon: 'photo',
+      icon: 'shapes',
       name: 'Image',
       path: 'components/media/image',
     },
     {
-      icon: 'video-camera',
+      icon: 'video',
       name: 'Video',
       path: 'components/media/video',
     },

--- a/apps/playground/src/app/components/stache/stache-playground.component.ts
+++ b/apps/playground/src/app/components/stache/stache-playground.component.ts
@@ -11,17 +11,17 @@ import { StacheNavLink } from '@blackbaud/skyux-lib-stache';
 export class StachePlaygroundComponent {
   public actionButtonRoutes: StacheNavLink[] = [
     {
-      icon: 'thumbs-up',
+      icon: 'thumb-like',
       name: 'Action button 1',
       path: '/foobar-1',
     },
     {
-      icon: 'thumbs-down',
+      icon: 'thumb-dislike',
       name: 'Action button 2',
       path: '/foobar-2',
     },
     {
-      icon: 'file',
+      icon: 'document',
       name: 'Action button 3',
       path: '/foobar-3',
     },

--- a/libs/stache/src/lib/modules/action-buttons/action-buttons.component.html
+++ b/libs/stache/src/lib/modules/action-buttons/action-buttons.component.html
@@ -21,7 +21,7 @@
             >
               <div>
                 @if (route.icon) {
-                  <sky-action-button-icon [iconType]="route.icon" />
+                  <sky-action-button-icon [iconName]="route.icon" />
                 }
                 <sky-action-button-header>
                   {{ route.name }}

--- a/libs/stache/src/lib/modules/action-buttons/action-buttons.component.spec.ts
+++ b/libs/stache/src/lib/modules/action-buttons/action-buttons.component.spec.ts
@@ -68,7 +68,7 @@ describe('StacheActionButtonsComponent', () => {
     component.routes = [
       {
         name: 'Test',
-        icon: 'fa-circle',
+        icon: 'edit',
         summary: '',
         path: [],
       },
@@ -86,7 +86,7 @@ describe('StacheActionButtonsComponent', () => {
     component.routes = [
       {
         name: 'Test',
-        icon: 'fa-circle',
+        icon: 'edit',
         summary: '',
         path: [],
       },

--- a/libs/stache/src/lib/modules/action-buttons/action-buttons.component.ts
+++ b/libs/stache/src/lib/modules/action-buttons/action-buttons.component.ts
@@ -5,6 +5,9 @@ import { booleanConverter } from '../shared/input-converter';
 
 const SEARCH_KEYS: (keyof StacheNavLink)[] = ['name', 'summary'];
 
+/**
+ * @deprecated Use SKY UX action buttons instead: https://developer.blackbaud.com/skyux/components/action-button
+ */
 @Component({
   selector: 'stache-action-buttons',
   templateUrl: './action-buttons.component.html',


### PR DESCRIPTION
[AB#3519134](https://dev.azure.com/blackbaud/f565481a-7bc9-4083-95d5-4f953da6d499/_workitems/edit/3519134)

BREAKING CHANGE:

Stache action buttons now take in SVG icon names. Icons will need to be updated to utilize new SVG values. See the SKY UX migration guide for more information on the update to SVG icons.